### PR TITLE
Fix DFW scraper fallbacks and restore wait-time estimates

### DIFF
--- a/dfw/index.html
+++ b/dfw/index.html
@@ -34,38 +34,81 @@
   </section>
 </div>
 <script>
-const state={lane:'pre',rows:[],updatedAt:null,error:null};
+const state={lane:'pre',rows:[],updatedAt:null,error:null,source:'unknown'};
 const tabs=[...document.querySelectorAll('.tab')],grid=document.getElementById('grid'),statusEl=document.getElementById('status');
+const PRECHECK_GATES=new Set(['A21','C21','D30','E16']);
 for(const t of tabs){t.onclick=()=>{state.lane=t.dataset.lane;tabs.forEach(b=>b.classList.toggle('active',b===t));render();};}
-function normalize(rows){return rows.map(r=>({gate:r.gate||r.checkpoint||r.location||'Unknown',wait:r.wait||r.estimate||r.time||'Unknown',lane:(r.lane||r.type||'general').toLowerCase().includes('pre')?'pre':'general'}));}
+function normalizeRows(rows){
+  return rows
+    .map(r=>({
+      gate:String(r.gate||r.checkpoint||r.location||'Unknown').toUpperCase(),
+      wait:String(r.wait||r.estimate||r.time||'Unknown').replace(/\s+/g,' ').trim(),
+      lane:(r.lane||r.type||'general').toLowerCase().includes('pre')?'pre':'general'
+    }))
+    .filter(r=>r.gate!=='UNKNOWN');
+}
+function parseDFWText(text){
+  const rows=[];
+  const seen=new Set();
+  for(const line of text.split('\n')){
+    const m=line.match(/\b([A-E]\d{1,2})\b.{0,40}\b(Closed|\d+\s*(?:-|to)\s*\d+\s*min|\d+\s*min|No wait)\b/i);
+    if(!m) continue;
+    const gate=m[1].toUpperCase();
+    if(seen.has(gate)) continue;
+    seen.add(gate);
+    rows.push({gate,wait:m[2],lane:PRECHECK_GATES.has(gate)?'pre':'general'});
+  }
+  return rows;
+}
+function splitPrecheckFromGeneral(rows){
+  const general=rows.filter(r=>r.lane==='general');
+  const pre=general.filter(r=>PRECHECK_GATES.has(r.gate)).map(r=>({...r,lane:'pre'}));
+  return [...general,...pre];
+}
+async function fetchJson(url){
+  const res=await fetch(url,{headers:{'Accept':'application/json,text/plain'}});
+  if(!res.ok) throw new Error(`${url} -> ${res.status}`);
+  return res.json();
+}
+async function fetchText(url){
+  const res=await fetch(url);
+  if(!res.ok) throw new Error(`${url} -> ${res.status}`);
+  return res.text();
+}
 async function fetchData(){
-  const endpoints=[
-    'https://www.dfwairport.com/api/security-wait-times',
-    'https://www.dfwairport.com/api/security/wait-times',
-    'https://www.tsawaittimes.com/security-wait-times/DFW.json'
+  const jsonSources=[
+    {name:'tsa-wait-times',url:'https://www.tsawaittimes.com/security-wait-times/DFW.json'},
+    {name:'ifly',url:'https://www.ifly.com/airports/dfw-dallas-fort-worth-international-airport/wait-times'}
   ];
-  for(const ep of endpoints){
-    try{const res=await fetch(ep,{headers:{'Accept':'application/json'}});if(!res.ok) continue;const data=await res.json();
-      const rows=normalize(data.checkpoints||data.data||data);
-      if(rows.length) return rows;
+  for(const src of jsonSources){
+    try{
+      const data=await fetchJson(src.url);
+      const rows=normalizeRows(data.checkpoints||data.data||data);
+      if(rows.length) return {rows:splitPrecheckFromGeneral(rows),source:src.name};
     }catch(e){}
   }
-  // scrape fallback via jina mirror
-  const txt=await (await fetch('https://r.jina.ai/http://www.dfwairport.com/security/')).text();
-  const out=[];const lines=txt.split('\n');
-  for(const line of lines){const m=line.match(/([A-E]\d{1,2}).{0,30}(Closed|\d+\s*-\s*\d+\s*min|\d+\s*min)/i);if(m){out.push({gate:m[1],wait:m[2],lane:'general'});} }
-  const preGates=['A21','C21','D30','E16'];
-  preGates.forEach(g=>out.push({gate:g,wait:'See estimate',lane:'pre'}));
-  return out;
+
+  const textSources=[
+    {name:'dfw-jina',url:'https://r.jina.ai/http://www.dfwairport.com/security/'},
+    {name:'dfw-jina-https',url:'https://r.jina.ai/http://https://www.dfwairport.com/security/'}
+  ];
+  for(const src of textSources){
+    try{
+      const text=await fetchText(src.url);
+      const parsed=parseDFWText(text);
+      if(parsed.length) return {rows:splitPrecheckFromGeneral(parsed),source:src.name};
+    }catch(e){}
+  }
+  throw new Error('All wait-time sources failed');
 }
 function render(){
   const rows=state.rows.filter(r=>r.lane===state.lane);
   grid.innerHTML=rows.map(r=>`<article class="card"><div class="gate">Checkpoint ${r.gate}</div><div class="wait">${r.wait}</div><div class="meta">${state.lane==='pre'?'TSA PreCheck':'General'} lane</div></article>`).join('')||'<p class="meta">No data available for this lane right now.</p>';
   const ts=state.updatedAt?new Date(state.updatedAt).toLocaleTimeString():'';
-  statusEl.textContent=state.error?`Live source unavailable, showing best-effort data. Last refresh: ${ts}`:`Updated ${ts} · auto-refresh every 60s`;
+  statusEl.textContent=state.error?`Live sources unavailable (${state.error}). Last refresh: ${ts}`:`Updated ${ts} · source: ${state.source} · auto-refresh every 60s`;
 }
 async function refresh(){
-  try{state.rows=await fetchData();state.error=null;}catch(e){state.error=e.message;}
+  try{const result=await fetchData();state.rows=result.rows;state.source=result.source;state.error=null;}catch(e){state.error=e.message;state.rows=[];}
   state.updatedAt=Date.now();render();
 }
 refresh();setInterval(refresh,60000);


### PR DESCRIPTION
### Motivation
- The DFW security wait widget relied on endpoints that are often blocked (403) and produced no usable estimated wait times, so a more robust multi-source fallback and parser were needed to restore live estimates. 
- TSA PreCheck showed placeholder values instead of estimates, so PreCheck rows should be derived from known checkpoints when general estimates exist.

### Description
- Updated `dfw/index.html` to add `PRECHECK_GATES`, a `normalizeRows` function, `parseDFWText` extractor, `splitPrecheckFromGeneral`, and helper fetchers `fetchJson`/`fetchText` to centralize parsing and normalization. 
- Reworked `fetchData` to try structured JSON sources first (`https://www.tsawaittimes.com/...`, `https://www.ifly.com/...`) and then text fallbacks (jina.ai mirrors), and to return a named `source` or throw a clear error if all sources fail. 
- Normalization now uppercases checkpoint IDs, cleans wait strings, generates PreCheck rows from matching general checkpoints, and sets `state.source` for improved UI status messaging. 
- Created a new branch `fix/dfw-scraper-fallback` and committed the changes.

### Testing
- Ran `git diff --check` which completed successfully. 
- Ran a quick content check with `node -e "const fs=require('fs');const s=fs.readFileSync('dfw/index.html','utf8');console.log(s.includes('fetchData()')?'ok':'missing')"` which printed `ok`. 
- Created and committed the change on the new branch using `git checkout -b fix/dfw-scraper-fallback` and `git add`/`git commit`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa5dd80fac8331b47b96507cb6ed4d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the live data acquisition/parsing path and adds new third-party sources; failures could result in empty data or misleading lane attribution.
> 
> **Overview**
> Restores DFW wait-time estimates by reworking `fetchData()` to try multiple JSON sources first and then scrape text fallbacks, returning a `{rows, source}` result and surfacing a clear error when all sources fail.
> 
> Normalizes and de-duplicates checkpoint rows (uppercasing gates, cleaning wait strings), derives TSA PreCheck rows from known checkpoints via `PRECHECK_GATES`, and updates the UI status line to display the active data source and more explicit error details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafeddac928c4a108489f2c2605c78d2fae84932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->